### PR TITLE
feat: add mobile navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css'
 import Image from 'next/image'
-import Link from 'next/link'
 import type { Metadata } from 'next'
+import Header from '@/components/Header'
 
 export const metadata: Metadata = {
   title: 'Vacation Avocation — Fun Food & Travel Guides',
@@ -12,45 +12,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className="min-h-screen">
-        {/* Header */}
-        <header className="sticky top-0 z-40 bg-white/80 backdrop-blur border-b border-slate-200">
-          <div className="container h-16 flex items-center justify-between">
-            <Link href="/" className="flex items-center gap-3">
-              <Image
-                src="/logo-with-text.png"
-                alt="Vacation Avocation"
-                width={180}
-                height={48}
-                priority
-              />
-            </Link>
-
-            <nav className="hidden md:flex items-center gap-6 font-semibold">
-              <Link href="/" className="hover:text-[#F47174]">Home</Link>
-              <Link href="/guides" className="hover:text-[#F47174]">Guides</Link>
-              <Link href="/blog" className="hover:text-[#F47174]">Blog</Link>
-              <Link href="/contact" className="hover:text-[#F47174]">Contact</Link>
-              <Link
-                href="/subscribe"
-                className="inline-flex px-4 py-2 rounded-lg bg-[#F47174] text-white font-semibold"
-              >
-                Subscribe
-              </Link>
-            </nav>
-          </div>
-
-          <div className="border-t border-slate-200">
-            <div className="container py-2 flex justify-end">
-              <form action="/search" className="hidden md:block">
-                <input
-                  name="q"
-                  placeholder="Search guides..."
-                  className="border rounded-lg px-3 py-1.5 text-sm"
-                />
-              </form>
-            </div>
-          </div>
-        </header>
+        <Header />
 
         {/* Page content */}
         {children}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import Navigation from './Navigation'
+
+export default function Header() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <header className="sticky top-0 z-40 bg-white/80 backdrop-blur border-b border-slate-200">
+      <div className="container h-16 flex items-center justify-between">
+        <Link href="/" className="flex items-center gap-3">
+          <Image
+            src="/logo-with-text.png"
+            alt="Vacation Avocation"
+            width={180}
+            height={48}
+            priority
+          />
+        </Link>
+
+        <button
+          className="md:hidden p-2"
+          onClick={() => setOpen(!open)}
+          aria-label="Toggle menu"
+        >
+          <svg
+            className="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        </button>
+
+        <Navigation className="hidden md:flex" />
+      </div>
+
+      <div className="border-t border-slate-200">
+        <div className="container py-2 flex justify-end">
+          <form action="/search" className="hidden md:block">
+            <input
+              name="q"
+              placeholder="Search guides..."
+              className="border rounded-lg px-3 py-1.5 text-sm"
+            />
+          </form>
+        </div>
+      </div>
+
+      <div
+        className={`fixed inset-0 z-30 bg-white transition-transform duration-300 md:hidden ${
+          open ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="h-16 flex items-center justify-between px-4 border-b border-slate-200">
+          <Link href="/" className="flex items-center gap-3" onClick={() => setOpen(false)}>
+            <Image
+              src="/logo-with-text.png"
+              alt="Vacation Avocation"
+              width={180}
+              height={48}
+              priority
+            />
+          </Link>
+          <button className="p-2" onClick={() => setOpen(false)} aria-label="Close menu">
+            <svg
+              className="h-6 w-6"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="p-6">
+          <Navigation onLinkClick={() => setOpen(false)} />
+        </div>
+      </div>
+    </header>
+  )
+}
+

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import Link from 'next/link'
+
+interface NavigationProps {
+  className?: string
+  onLinkClick?: () => void
+}
+
+export default function Navigation({ className = '', onLinkClick }: NavigationProps) {
+  const linkClasses = 'hover:text-[#F47174]'
+
+  return (
+    <nav className={`flex flex-col gap-4 md:flex-row md:items-center md:gap-6 font-semibold ${className}`}>
+      <Link href="/" className={linkClasses} onClick={onLinkClick}>
+        Home
+      </Link>
+      <Link href="/guides" className={linkClasses} onClick={onLinkClick}>
+        Guides
+      </Link>
+      <Link href="/blog" className={linkClasses} onClick={onLinkClick}>
+        Blog
+      </Link>
+      <Link href="/contact" className={linkClasses} onClick={onLinkClick}>
+        Contact
+      </Link>
+      <Link
+        href="/subscribe"
+        className="inline-flex px-4 py-2 rounded-lg bg-[#F47174] text-white font-semibold"
+        onClick={onLinkClick}
+      >
+        Subscribe
+      </Link>
+    </nav>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add reusable `Navigation` component for main links
- implement `Header` with hamburger-driven mobile menu
- update layout to use new header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1e576726c8320b99ea61eb0cfe71b