### PR TITLE
Replace site branding with updated Vacation Avocation logos

### DIFF
--- a/public/logo-text.svg
+++ b/public/logo-text.svg
@@ -1,7 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 64">
-  <g>
-    <path d="M32 0C14 0 0 20 0 32s14 32 32 32 32-14 32-32S50 0 32 0z" fill="#6B8E23"/>
-    <circle cx="32" cy="36" r="14" fill="#8B5E3C"/>
-    <text x="70" y="42" font-size="28" font-family="Arial, sans-serif" fill="#6B8E23">Vacation Avocation</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 120">
+  <g transform="translate(0,20)">
+    <path d="M5 40 L75 40 L90 30 L110 30 L95 40 L110 50 L90 50 L75 40 L5 40 Z" fill="#FACC15" stroke="#365314" stroke-width="2"/>
+    <ellipse cx="40" cy="30" rx="15" ry="20" fill="#65a30d" stroke="#365314" stroke-width="2"/>
+    <circle cx="40" cy="37" r="8" fill="#8B5E3C"/>
+    <circle cx="35" cy="25" r="2" fill="#000"/>
+    <circle cx="45" cy="25" r="2" fill="#000"/>
+    <path d="M35 29 Q40 33 45 29" stroke="#000" stroke-width="1.5" fill="none" stroke-linecap="round"/>
   </g>
+  <text x="140" y="65" font-family="Poppins, Arial, sans-serif" font-size="36" font-weight="600" fill="#f87171">Vacation</text>
+  <text x="140" y="105" font-family="Poppins, Arial, sans-serif" font-size="36" font-weight="600" fill="#365314">Avocation</text>
 </svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,4 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <path d="M32 0C14 0 0 20 0 32s14 32 32 32 32-14 32-32S50 0 32 0z" fill="#6B8E23"/>
-  <circle cx="32" cy="36" r="14" fill="#8B5E3C"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80">
+  <!-- airplane body -->
+  <path d="M5 40 L75 40 L90 30 L110 30 L95 40 L110 50 L90 50 L75 40 L5 40 Z" fill="#FACC15" stroke="#365314" stroke-width="2"/>
+  <!-- avocado -->
+  <ellipse cx="40" cy="30" rx="15" ry="20" fill="#65a30d" stroke="#365314" stroke-width="2"/>
+  <circle cx="40" cy="37" r="8" fill="#8B5E3C"/>
+  <!-- face -->
+  <circle cx="35" cy="25" r="2" fill="#000"/>
+  <circle cx="45" cy="25" r="2" fill="#000"/>
+  <path d="M35 29 Q40 33 45 29" stroke="#000" stroke-width="1.5" fill="none" stroke-linecap="round"/>
 </svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,7 @@ export default function Home() {
         <Image src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1600&q=80" alt="Beach vacation" fill className="object-cover" priority />
         <div className="absolute inset-0 bg-ink/40" />
         <div className="relative z-10 flex flex-col items-center justify-center h-full text-center text-paper space-y-4 px-4">
-          <Image src="/logo.svg" alt="Vacation Avocation" width={96} height={96} />
+          <Image src="/logo.svg" alt="Vacation Avocation" width={120} height={80} />
           <h1 className="text-4xl md:text-6xl font-heading">Vacation Avocation</h1>
           <p className="text-lg md:text-xl">Fun food & travel guides.</p>
           <div className="flex gap-4 flex-wrap justify-center">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,7 +14,7 @@ export default function Footer() {
   return (
     <footer className="mt-24 bg-ink text-paper">
       <div className="container py-16 space-y-6 text-center">
-        <Image src="/logo.svg" alt="Avocado plane" width={80} height={80} />
+        <Image src="/logo.svg" alt="Avocado plane" width={120} height={80} />
         <p className="text-lg font-heading">Fun food & travel guides.</p>
         <p className="max-w-prose mx-auto text-sm">
           Vacation Avocation helps you find the tastiest bites and brightest trips. Follow along for cheeky itineraries and bold flavours.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
     <header className="sticky top-0 z-50 bg-paper/80 backdrop-blur border-b border-slate-200">
       <div className="container flex items-center justify-between h-16">
         <Link href="/" className="flex items-center">
-          <Image src="/logo-text.svg" alt="Vacation Avocation" width={160} height={40} priority />
+          <Image src="/logo-text.svg" alt="Vacation Avocation" width={210} height={60} priority />
         </Link>
         <nav className="hidden md:flex items-center gap-6 font-heading text-sm">
           {links.map((l) =>

--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -1,11 +1,20 @@
 'use client'
 
+import Image from 'next/image'
+
 export default function NewsletterForm() {
   return (
     <form
-      className="w-full flex flex-col sm:flex-row gap-4"
+      className="w-full flex flex-col sm:flex-row gap-4 items-center"
       onSubmit={(e) => e.preventDefault()}
     >
+      <Image
+        src="/logo.svg"
+        alt="Vacation Avocation"
+        width={60}
+        height={40}
+        className="mb-2 sm:mb-0"
+      />
       <label htmlFor="email" className="sr-only">
         Email address
       </label>


### PR DESCRIPTION
## Summary
- add new text logo and avocado-plane icon assets
- show text logo in header on every page
- display avocado-plane icon in footer and newsletter form for consistent branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2344b39e0832098c58fa068678c18