### PR TITLE
feat: replace homepage hero with svg

### DIFF
--- a/public/home-hero.svg
+++ b/public/home-hero.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="sky" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#7ec8e3" />
+      <stop offset="100%" stop-color="#e0f7fa" />
+    </linearGradient>
+    <linearGradient id="ocean" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0277bd" />
+      <stop offset="100%" stop-color="#00bcd4" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#sky)" />
+  <path d="M0 400 L200 350 L400 380 L600 360 L800 370 L1200 330 L1200 630 L0 630 Z" fill="url(#ocean)" />
+  <path d="M0 400 L200 350 L250 370 L0 430 Z" fill="#c8b560" />
+  <path d="M200 350 L400 380 L450 360 L200 330 Z" fill="#b29957" />
+  <path d="M400 380 L600 360 L650 380 L400 400 Z" fill="#a2844c" />
+  <path d="M600 360 L800 370 L850 350 L600 330 Z" fill="#8d7543" />
+  <path d="M800 370 L1200 330 L1200 400 L800 400 Z" fill="#7c653b" />
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
     siteName: 'Vacation Avocation',
     images: [
       {
-        url: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1200&q=80',
+        url: 'https://vacationavocation.com/home-hero.svg',
         width: 1200,
         height: 630,
         alt: 'Vacation Avocation',
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Vacation Avocation | Fun food & travel guides',
     description: 'Tight itineraries, cheeky vibes, hidden eats — all killer, no filler.',
-    images: ['https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1200&q=80'],
+    images: ['https://vacationavocation.com/home-hero.svg'],
   },
 }
 
@@ -37,7 +37,7 @@ export default function Home() {
   return (
     <main>
       <section className="relative h-[45vh] md:h-[60vh]">
-        <Image src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1600&q=80" alt="Beach vacation" fill className="object-cover" priority />
+        <Image src="/home-hero.svg" alt="Cliffside illustration" fill className="object-cover" priority />
         <div className="absolute inset-0 bg-ink/40" />
         <div className="relative z-10 flex flex-col items-center justify-center h-full text-center text-paper space-y-4 px-4">
 


### PR DESCRIPTION
## Summary
- swap homepage hero to use a text-based SVG asset
- update Open Graph and Twitter metadata references
- drop PNG hero and its gitignore exception

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2528850848320ae75d480c7179095