### PR TITLE
Part 1 foundations: navigation, tokens, newsletter

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,15 +1,7 @@
+@import '../styles/tokens.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-:root {
-  --brand: #16A34A;
-  --accent1: #1D4ED8;
-  --accent2: #F59E0B;
-  --ink: #0B1220;
-  --paper: #F8FAFC;
-  --ring: var(--accent1);
-}
 
 * {
   box-sizing: border-box;

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
 import FiltersClient from '@/components/FiltersClient'
+import NewsletterForm from '@/components/NewsletterForm'
 
 export const metadata: Metadata = {
   title: 'Travel Guides | Vacation Avocation',
@@ -40,7 +41,7 @@ const continents = [
 
 export default function Guides() {
   return (
-    <main className="max-w-6xl mx-auto px-4 py-12">
+    <main className="max-w-6xl mx-auto px-4 py-12 space-y-8">
       <h1 className="text-3xl font-semibold mb-6">Guides</h1>
       <FiltersClient />
       <div className="mt-6 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
@@ -65,6 +66,10 @@ export default function Guides() {
           )
         )}
       </div>
+      <section className="bg-accent2/20 py-8 rounded-xl2 text-center">
+        <h2 className="text-2xl font-heading mb-4">Get fresh guides in your inbox</h2>
+        <NewsletterForm />
+      </section>
     </main>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${poppins.variable} ${inter.variable}`}>
+      <head>
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+      </head>
       <body className="min-h-screen">
         <Header />
         {children}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,27 +1,27 @@
 import Image from 'next/image'
 import Link from 'next/link'
+import NewsletterForm from '@/components/NewsletterForm'
 
 const links = [
   { href: '/about', label: 'About Us' },
-  { href: '/destinations', label: 'Destinations' },
-  { href: '/restaurants', label: 'Restaurants' },
-  { href: '/travel-resources', label: 'Travel Resources' },
-  { href: '/travel-reward-credit-cards', label: 'Travel Reward Credit Cards' },
-  { href: '/travel-gear', label: 'Travel Gear' },
+  { href: '/privacy', label: 'Privacy' },
+  { href: '/sitemap.xml', label: 'Sitemap' },
+  { href: 'mailto:support@vacationavocation.com', label: 'Contact' },
 ]
 
 export default function Footer() {
   return (
     <footer className="mt-24 bg-ink text-paper">
       <div className="container py-16 space-y-6 text-center">
-          <Image src="/logo.svg" alt="Avocado plane icon" width={100} height={50} className="mx-auto rotate-6" />
+        <Image src="/logo.svg" alt="Avocado plane icon" width={100} height={50} className="mx-auto rotate-6" />
         <p className="text-lg font-heading">Fun food & travel guides.</p>
         <p className="max-w-prose mx-auto text-sm">
           Vacation Avocation helps you find the tastiest bites and brightest trips. Follow along for cheeky itineraries and bold flavours.
         </p>
-        <nav className="flex flex-wrap justify-center gap-4 text-sm">
+        <NewsletterForm />
+        <nav className="flex flex-wrap justify-center gap-4 text-sm" aria-label="Footer">
           {links.map((l) => (
-            <Link key={l.href} href={l.href} className="hover:underline">
+            <Link key={l.href} href={l.href} className="hover:underline focus-visible:ring-brand">
               {l.label}
             </Link>
           ))}
@@ -37,10 +37,7 @@ export default function Footer() {
             </svg>
           </a>
         </div>
-        <p className="text-xs opacity-80">
-          © {new Date().getFullYear()} Vacation Avocation · <Link href="/privacy" className="underline">Privacy</Link> ·{' '}
-          <Link href="/sitemap.xml" className="underline">Sitemap</Link>
-        </p>
+        <p className="text-xs opacity-80">© {new Date().getFullYear()} Vacation Avocation</p>
       </div>
     </footer>
   )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { useState } from 'react'
+import { usePathname } from 'next/navigation'
 
 type NavLink = {
   href?: string
@@ -21,26 +22,18 @@ const links: NavLink[] = [
       { href: '/destinations/south-america', label: 'South America' },
     ],
   },
-  { href: '/restaurants', label: 'Restaurants' },
-  {
-    label: 'Key Travel Resources',
-    children: [
-      { href: '/travel-resources', label: 'Travel Resources' },
-      { href: '/travel-reward-credit-cards', label: 'Travel Reward Credit Cards' },
-      { href: '/travel-gear', label: 'Travel Gear' },
-    ],
-  },
 ]
 
 export default function Header() {
   const [open, setOpen] = useState(false)
+  const pathname = usePathname()
   return (
     <header className="sticky top-0 z-50 bg-paper/80 backdrop-blur border-b border-slate-200">
       <div className="container flex items-center justify-between h-16">
-        <Link href="/" className="flex items-center">
+        <Link href="/" className="flex items-center focus-visible:ring-brand">
           <Image src="/logo-text.svg" alt="Vacation Avocation" width={200} height={50} priority />
         </Link>
-        <nav className="hidden md:flex items-center gap-6 font-heading text-sm">
+        <nav className="hidden md:flex items-center gap-6 font-heading text-sm" aria-label="Primary">
           {links.map((l) =>
             l.children ? (
               <div key={l.label} className="relative group">
@@ -51,7 +44,10 @@ export default function Header() {
                       <li key={c.href}>
                         <Link
                           href={c.href!}
-                          className="block px-4 py-2 whitespace-nowrap hover:bg-paper/50 hover:text-brand"
+                          className={`block px-4 py-2 whitespace-nowrap hover:bg-paper/50 hover:text-brand ${
+                            pathname === c.href ? 'text-brand font-semibold' : ''
+                          }`}
+                          aria-current={pathname === c.href ? 'page' : undefined}
                         >
                           {c.label}
                         </Link>
@@ -61,7 +57,12 @@ export default function Header() {
                 </div>
               </div>
             ) : (
-              <Link key={l.href} href={l.href!} className="hover:text-brand">
+              <Link
+                key={l.href}
+                href={l.href!}
+                className={`${pathname === l.href ? 'text-brand font-semibold' : 'hover:text-brand'}`}
+                aria-current={pathname === l.href ? 'page' : undefined}
+              >
                 {l.label}
               </Link>
             )
@@ -85,23 +86,37 @@ export default function Header() {
         </nav>
         <button
           className="md:hidden p-2"
-          aria-label="Toggle menu"
+          aria-label={open ? 'Close menu' : 'Open menu'}
+          aria-expanded={open}
           onClick={() => setOpen(!open)}
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={2}
-            stroke="currentColor"
-            className="w-6 h-6"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5M3.75 18.75h16.5" />
-          </svg>
+          {open ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              className="w-6 h-6"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5M3.75 18.75h16.5" />
+            </svg>
+          )}
         </button>
       </div>
       {open && (
-        <nav className="md:hidden border-t border-slate-200 bg-paper">
+        <nav className="md:hidden border-t border-slate-200 bg-paper" aria-label="Mobile">
           <ul className="flex flex-col px-4 py-4 space-y-4">
             {links.map((l) => (
               <li key={l.label}>

--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -1,25 +1,44 @@
 'use client'
 
-import Image from 'next/image'
+import { useState } from 'react'
 
 export default function NewsletterForm() {
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle')
+  const [message, setMessage] = useState('')
+
+  const subscribe = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const form = e.currentTarget
+    const formData = new FormData(form)
+    try {
+      const res = await fetch(process.env.NEXT_PUBLIC_MAILCHIMP_URL!, {
+        method: 'POST',
+        body: formData,
+        headers: {
+          Accept: 'application/json',
+        },
+      })
+      if (res.ok) {
+        setStatus('success')
+        setMessage('Thanks! Check your inbox.')
+        form.reset()
+      } else {
+        throw new Error('Bad response')
+      }
+    } catch (err) {
+      setStatus('error')
+      setMessage('Oops! Something went wrong.')
+    }
+  }
+
   return (
-    <form
-      className="w-full flex flex-col sm:flex-row gap-4 items-center"
-      onSubmit={(e) => e.preventDefault()}
-    >
-      <Image
-        src="/logo.svg"
-        alt="Vacation Avocation"
-        width={60}
-        height={40}
-        className="mb-2 sm:mb-0"
-      />
+    <form className="w-full flex flex-col sm:flex-row gap-4 items-center" onSubmit={subscribe}>
       <label htmlFor="email" className="sr-only">
         Email address
       </label>
       <input
         id="email"
+        name="EMAIL"
         type="email"
         required
         placeholder="you@example.com"
@@ -27,10 +46,15 @@ export default function NewsletterForm() {
       />
       <button
         type="submit"
-        className="px-6 py-3 rounded-xl bg-brand text-white font-semibold hover:bg-brand/90"
+        className="px-6 py-3 rounded-xl bg-brand text-white font-semibold hover:bg-brand/90 focus-visible:ring-brand"
       >
-        Join free
+        Join Free
       </button>
+      {status !== 'idle' && (
+        <p role="alert" className={`text-sm ${status === 'success' ? 'text-brand' : 'text-red-600'}`}>
+          {message}
+        </p>
+      )}
     </form>
   )
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,20 @@
+:root {
+  --brand: #6B8E23;
+  --accent1: #A6D785;
+  --accent2: #8B5E3C;
+  --ink: #0B1220;
+  --paper: #F8FAFC;
+  --ring: var(--accent1);
+
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 2rem;
+
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 1rem;
+
+  --font-heading: var(--font-poppins);
+  --font-body: var(--font-inter);
+}


### PR DESCRIPTION
## Summary
- centralize design tokens for color, spacing, radii and typography
- refine header navigation with active states and accessible mobile toggle
- add newsletter sign-up with Mailchimp endpoint and footer links
- preconnect fonts for faster rendering

## Testing
- `npm run build`
- `npx --yes lighthouse https://vacationavocation.com --quiet --chrome-flags="--headless"` *(fails: The CHROME_PATH environment variable must be set to a Chrome/Chromium executable no older than Chrome stable.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c41847b08320be343878fca51470