### PR TITLE
feat: guides hub with filters and map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Vacation Avocation
+
+## Adding a new guide
+1. Add an entry to `public/data/guides.json` with:
+   - `title`, `excerpt`, `continent`, `country`, `city`, `url`, `themes`, `length`, `season`, `updated`, `latitude`, `longitude`, `image`.
+2. Optionally drop a draft Markdown file in `guides-drafts/` for preview work.
+3. Create a page at the `url` you specified under `src/app` if it does not already exist.
+
+## Newsletter signup
+Mailchimp form settings live in `src/components/NewsletterForm.tsx`. Paste your Mailchimp action URL and any hidden inputs into that component.

--- a/public/data/guides.json
+++ b/public/data/guides.json
@@ -1,0 +1,47 @@
+[
+  {
+    "title": "Weekend in New York",
+    "excerpt": "A quick guide to the Big Apple.",
+    "continent": "North America",
+    "country": "USA",
+    "city": "New York",
+    "url": "/guides/new-york-weekend",
+    "themes": ["City Break", "Food"],
+    "length": "Weekend",
+    "season": ["Spring", "Autumn"],
+    "updated": "2024-01-01",
+    "latitude": 40.7128,
+    "longitude": -74.0060,
+    "image": "https://images.unsplash.com/photo-1534447677768-be436bb09401?auto=format&fit=crop&w=800&q=80"
+  },
+  {
+    "title": "Paris Food Guide",
+    "excerpt": "Bistros and bakeries in the City of Light.",
+    "continent": "Europe",
+    "country": "France",
+    "city": "Paris",
+    "url": "/guides/paris-food",
+    "themes": ["Food"],
+    "length": "1 Week",
+    "season": ["Spring", "Summer"],
+    "updated": "2024-02-01",
+    "latitude": 48.8566,
+    "longitude": 2.3522,
+    "image": "https://images.unsplash.com/photo-1502602898657-3e91760cbb34?auto=format&fit=crop&w=800&q=80"
+  },
+  {
+    "title": "Tokyo Adventure Guide",
+    "excerpt": "High-tech thrills and hidden temples.",
+    "continent": "Asia",
+    "country": "Japan",
+    "city": "Tokyo",
+    "url": "/guides/tokyo-adventure",
+    "themes": ["Adventure", "City Break"],
+    "length": "1 Week",
+    "season": ["Autumn"],
+    "updated": "2024-03-01",
+    "latitude": 35.6762,
+    "longitude": 139.6503,
+    "image": "https://images.unsplash.com/photo-1568084205274-00e5c1d52cc7?auto=format&fit=crop&w=800&q=80"
+  }
+]

--- a/src/app/guides/new-york-weekend/page.tsx
+++ b/src/app/guides/new-york-weekend/page.tsx
@@ -1,0 +1,24 @@
+import Gallery from '@/components/Gallery'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'Weekend in New York - Vacation Avocation' }
+
+export default function NewYorkWeekend() {
+  const images = [
+    {
+      src: 'https://images.unsplash.com/photo-1549924231-f129b911e442?auto=format&fit=crop&w=800&q=80',
+      alt: 'Times Square',
+    },
+    {
+      src: 'https://images.unsplash.com/photo-1502735325653-4a4581235761?auto=format&fit=crop&w=800&q=80',
+      alt: 'Central Park',
+    },
+  ]
+  return (
+    <main className="container py-12 prose">
+      <h1>Weekend in New York</h1>
+      <p>Quick hits and tasty bites in the Big Apple.</p>
+      <Gallery images={images} />
+    </main>
+  )
+}

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,6 +1,5 @@
-import Link from 'next/link'
 import type { Metadata } from 'next'
-import FiltersClient from '@/components/FiltersClient'
+import GuidesClient from '@/components/GuidesClient'
 
 export const metadata: Metadata = {
   title: 'Travel Guides | Vacation Avocation',
@@ -28,43 +27,11 @@ export const metadata: Metadata = {
   },
 }
 
-const continents = [
-  { slug: 'africa', name: 'Africa', disabled: false },
-  { slug: 'asia', name: 'Asia', disabled: false },
-  { slug: 'europe', name: 'Europe', disabled: false },
-  { slug: 'north-america', name: 'North America', disabled: false },
-  { slug: 'south-america', name: 'South America', disabled: false },
-  { slug: 'oceania', name: 'Oceania (TBC)', disabled: true },
-  { slug: 'antarctica', name: 'Antarctica (TBC)', disabled: true },
-]
-
 export default function Guides() {
   return (
     <main className="max-w-6xl mx-auto px-4 py-12">
       <h1 className="text-3xl font-semibold mb-6">Guides</h1>
-      <FiltersClient />
-      <div className="mt-6 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-        {continents.map((c) =>
-          c.disabled ? (
-            <div
-              key={c.slug}
-              className="rounded-xl2 border p-4 opacity-60 cursor-not-allowed"
-              aria-disabled="true"
-              title="Coming soon"
-            >
-              {c.name}
-            </div>
-          ) : (
-            <Link
-              key={c.slug}
-              href={`/guides/${c.slug}`}
-              className="rounded-xl2 border p-4 hover:border-coral"
-            >
-              {c.name}
-            </Link>
-          )
-        )}
-      </div>
+      <GuidesClient />
     </main>
   )
 }

--- a/src/app/guides/paris-food/page.tsx
+++ b/src/app/guides/paris-food/page.tsx
@@ -1,0 +1,24 @@
+import Gallery from '@/components/Gallery'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'Paris Food Guide - Vacation Avocation' }
+
+export default function ParisFood() {
+  const images = [
+    {
+      src: 'https://images.unsplash.com/photo-1502602898657-3e91760cbb34?auto=format&fit=crop&w=800&q=80',
+      alt: 'Paris street',
+    },
+    {
+      src: 'https://images.unsplash.com/photo-1523986371872-9d3ba2e2f642?auto=format&fit=crop&w=800&q=80',
+      alt: 'Croissants',
+    },
+  ]
+  return (
+    <main className="container py-12 prose">
+      <h1>Paris Food Guide</h1>
+      <p>Bistros and bakeries in the City of Light.</p>
+      <Gallery images={images} />
+    </main>
+  )
+}

--- a/src/app/guides/tokyo-adventure/page.tsx
+++ b/src/app/guides/tokyo-adventure/page.tsx
@@ -1,0 +1,24 @@
+import Gallery from '@/components/Gallery'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'Tokyo Adventure Guide - Vacation Avocation' }
+
+export default function TokyoAdventure() {
+  const images = [
+    {
+      src: 'https://images.unsplash.com/photo-1568084205274-00e5c1d52cc7?auto=format&fit=crop&w=800&q=80',
+      alt: 'Tokyo skyline',
+    },
+    {
+      src: 'https://images.unsplash.com/photo-1549692520-acc6669e2f0c?auto=format&fit=crop&w=800&q=80',
+      alt: 'Shibuya crossing',
+    },
+  ]
+  return (
+    <main className="container py-12 prose">
+      <h1>Tokyo Adventure Guide</h1>
+      <p>High-tech thrills and hidden temples.</p>
+      <Gallery images={images} />
+    </main>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 import { Poppins, Inter } from 'next/font/google'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
+import BackToTop from '@/components/BackToTop'
 
 const poppins = Poppins({ subsets: ['latin'], weight: ['600','700'], variable: '--font-poppins', display: 'swap' })
 const inter = Inter({ subsets: ['latin'], weight: ['400'], variable: '--font-inter', display: 'swap' })
@@ -18,6 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="min-h-screen">
         <Header />
         {children}
+        <BackToTop />
         <Footer />
         <script
           type="application/ld+json"

--- a/src/app/restaurants/page.tsx
+++ b/src/app/restaurants/page.tsx
@@ -6,13 +6,27 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = { title: 'Restaurants - Vacation Avocation' }
 
 export default function Restaurants() {
+  const spots = [
+    { name: 'Joe\'s Pizza', city: 'New York', country: 'USA', note: 'Classic slice joint', url: 'https://www.joespizzanyc.com/' },
+    { name: 'Le Relais de l\'Entrecôte', city: 'Paris', country: 'France', note: 'Famous steak-frites', url: 'https://www.relaisentrecote.fr/' },
+    { name: 'Sushi Dai', city: 'Tokyo', country: 'Japan', note: 'Beloved fish market sushi', url: 'https://example.com' },
+    { name: 'Pizzeria Da Michele', city: 'Naples', country: 'Italy', note: 'Neapolitan classic', url: 'https://damichele.net/' },
+    { name: 'Hoppers', city: 'London', country: 'UK', note: 'Sri Lankan street food', url: 'https://hopperslondon.com/' },
+  ]
   return (
     <main className="container py-12 prose">
-
-        <h1 className="flex items-center gap-2">Restaurants
-          <Image src="/logo.svg" alt="Avocado plane icon" width={50} height={25} className="-rotate-12" />
-        </h1>
-      <p>Content coming soon.</p>
+      <h1 className="flex items-center gap-2">Restaurants
+        <Image src="/logo.svg" alt="Avocado plane icon" width={50} height={25} className="-rotate-12" />
+      </h1>
+      <ul>
+        {spots.map((s) => (
+          <li key={s.name}>
+            <a href={s.url} target="_blank" rel="noopener noreferrer">
+              {s.name}
+            </a> — {s.city}, {s.country}. {s.note}
+          </li>
+        ))}
+      </ul>
     </main>
   )
 }

--- a/src/app/travel-gear/page.tsx
+++ b/src/app/travel-gear/page.tsx
@@ -6,13 +6,28 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = { title: 'Travel Gear - Vacation Avocation' }
 
 export default function TravelGear() {
+  const gear = [
+    { name: 'Carry-on Backpack', note: 'Fits under most airline seats', url: 'https://example.com/backpack' },
+    { name: 'Noise-Cancelling Headphones', note: 'Peace on long flights', url: 'https://example.com/headphones' },
+    { name: 'Universal Adapter', note: 'Works in 150+ countries', url: 'https://example.com/adapter' },
+    { name: 'Packing Cubes', note: 'Stay organized', url: 'https://example.com/cubes' },
+    { name: 'Travel Water Bottle', note: 'Collapsible and leak-proof', url: 'https://example.com/bottle' },
+  ]
   return (
     <main className="container py-12 prose">
-
-        <h1 className="flex items-center gap-2">Travel Gear
-          <Image src="/logo.svg" alt="Avocado plane icon" width={50} height={25} className="-rotate-12" />
-        </h1>
-      <p>Content coming soon.</p>
+      <h1 className="flex items-center gap-2">Travel Gear
+        <Image src="/logo.svg" alt="Avocado plane icon" width={50} height={25} className="-rotate-12" />
+      </h1>
+      <p className="text-sm">Some product links are affiliate links; we may earn a small commission.</p>
+      <ul>
+        {gear.map((g) => (
+          <li key={g.url}>
+            <a href={g.url} target="_blank" rel="nofollow sponsored">
+              {g.name}
+            </a> — {g.note}
+          </li>
+        ))}
+      </ul>
     </main>
   )
 }

--- a/src/app/travel-resources/page.tsx
+++ b/src/app/travel-resources/page.tsx
@@ -4,12 +4,27 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = { title: 'Travel Resources - Vacation Avocation' }
 
 export default function TravelResources() {
+  const resources = [
+    { name: 'Google Flights', note: 'Find flight deals', url: 'https://www.google.com/flights' },
+    { name: 'SeatGuru', note: 'Airline seat maps', url: 'https://www.seatguru.com/' },
+    { name: 'Rome2Rio', note: 'Multi-modal route planning', url: 'https://www.rome2rio.com/' },
+    { name: 'XE Currency', note: 'Exchange rate calculator', url: 'https://www.xe.com/' },
+    { name: 'TripIt', note: 'Itinerary organizer', url: 'https://www.tripit.com/' },
+  ]
   return (
     <main className="container py-12 prose">
-        <h1 className="flex items-center gap-2">Travel Resources
-          <Image src="/logo.svg" alt="Avocado plane icon" width={50} height={25} className="rotate-12" />
-        </h1>
-      <p>Content coming soon.</p>
+      <h1 className="flex items-center gap-2">Travel Resources
+        <Image src="/logo.svg" alt="Avocado plane icon" width={50} height={25} className="rotate-12" />
+      </h1>
+      <ul>
+        {resources.map((r) => (
+          <li key={r.url}>
+            <a href={r.url} target="_blank" rel="noopener noreferrer">
+              {r.name}
+            </a> — {r.note}
+          </li>
+        ))}
+      </ul>
     </main>
   )
 }

--- a/src/app/travel-reward-credit-cards/page.tsx
+++ b/src/app/travel-reward-credit-cards/page.tsx
@@ -4,12 +4,26 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = { title: 'Travel Reward Credit Cards - Vacation Avocation' }
 
 export default function TravelRewardCreditCards() {
+  const cards = [
+    { name: 'Chase Sapphire Preferred', pros: 'Strong travel partners', cons: 'Annual fee', url: 'https://example.com/chase' },
+    { name: 'Capital One Venture', pros: 'Easy flat-rate earning', cons: 'Limited transfer partners', url: 'https://example.com/venture' },
+    { name: 'Amex Gold', pros: 'Great dining rewards', cons: 'Higher fee', url: 'https://example.com/amexgold' },
+    { name: 'Citi Premier', pros: 'Good bonus categories', cons: 'Fewer partners', url: 'https://example.com/citipremier' },
+    { name: 'Chase Freedom Flex', pros: 'Rotating bonuses', cons: 'Activation required', url: 'https://example.com/freedom' },
+  ]
   return (
     <main className="container py-12 prose">
-        <h1 className="flex items-center gap-2">Travel Reward Credit Cards
-          <Image src="/logo.svg" alt="Avocado plane icon" width={50} height={25} className="rotate-12" />
-        </h1>
-      <p>Content coming soon.</p>
+      <h1 className="flex items-center gap-2">Travel Reward Credit Cards
+        <Image src="/logo.svg" alt="Avocado plane icon" width={50} height={25} className="rotate-12" />
+      </h1>
+      <p className="text-sm">Some links may be affiliate links. We may earn a commission if you use them.</p>
+      <ul>
+        {cards.map((c) => (
+          <li key={c.name}>
+            <a href={c.url} target="_blank" rel="nofollow sponsored">{c.name}</a> — {c.pros}. {c.cons}
+          </li>
+        ))}
+      </ul>
     </main>
   )
 }

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export default function BackToTop(){
+  const [visible,setVisible]=useState(false)
+  useEffect(()=>{
+    const onScroll=()=>setVisible(window.scrollY>400)
+    window.addEventListener('scroll',onScroll)
+    return()=>window.removeEventListener('scroll',onScroll)
+  },[])
+  return (
+    <button
+      type="button"
+      onClick={()=>window.scrollTo({top:0,behavior:'smooth'})}
+      className={`fixed bottom-4 right-4 z-50 p-3 rounded-full bg-brand text-white shadow transition-opacity focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${visible?'opacity-100':'opacity-0 pointer-events-none'}`}
+      aria-hidden={!visible}
+      tabIndex={visible?0:-1}
+    >
+      ↑
+    </button>
+  )
+}

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -1,14 +1,48 @@
 'use client'
-import { useState } from 'react'
-const tripLengths=['Weekend','1 Week','2 Weeks','Longer']; const seasons=['Spring','Summer','Autumn','Winter']; const themes=['Food','Adventure','Luxury','Budget','City Break']
-export type FiltersState = { length?:string, season?:string, theme?:string }
-export default function Filters({ onChange }:{ onChange:(f:FiltersState)=>void }){
-  const [f,setF] = useState<FiltersState>({})
-  function setField(k: keyof FiltersState, v?: string){
-    const next={...f}
-    if(v===f[k]){ delete next[k] } else { next[k]=v }
-    setF(next); onChange(next)
+
+export type FiltersState={ length?:string; season?:string; theme?:string }
+
+const tripLengths=['Weekend','1 Week','2 Weeks','Longer']
+const seasons=['Spring','Summer','Autumn','Winter']
+const themes=['Food','Adventure','Luxury','Budget','City Break']
+
+export default function Filters({ state, onChange }:{ state:FiltersState, onChange:(f:FiltersState)=>void }){
+  function setField(k:keyof FiltersState, v:string){
+    const next={...state}
+    if(next[k]===v) delete next[k]
+    else next[k]=v
+    onChange(next)
   }
-  function Btn({k,v}:{k:keyof FiltersState,v:string}){ const active=f[k]===v; return <button type="button" onClick={()=>setField(k,v)} className={`px-3 py-1.5 rounded-lg border ${active?'bg-coral text-white border-coral':'hover:border-coral'}`}>{v}</button> }
-  return (<div className="space-y-3"><div className="flex flex-wrap gap-2 items-center"><span className="text-sm opacity-70 w-24">Trip Length</span>{tripLengths.map(v=><Btn key={v} k="length" v={v}/>)}</div><div className="flex flex-wrap gap-2 items-center"><span className="text-sm opacity-70 w-24">Season</span>{seasons.map(v=><Btn key={v} k="season" v={v}/>)}</div><div className="flex flex-wrap gap-2 items-center"><span className="text-sm opacity-70 w-24">Theme</span>{themes.map(v=><Btn key={v} k="theme" v={v}/>)}</div></div>)
+  function Btn({k,v}:{k:keyof FiltersState,v:string}){
+    const active=state[k]===v
+    return (
+      <button
+        type="button"
+        onClick={()=>setField(k,v)}
+        aria-pressed={active}
+        className={`px-3 py-1.5 rounded-lg border focus-visible:outline focus-visible:outline-2 focus-visible:outline-coral ${active?'bg-coral text-white border-coral':'hover:border-coral'}`}
+      >
+        {v}
+      </button>
+    )
+  }
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2 items-center">
+        <span className="text-sm opacity-70 w-24">Trip Length</span>
+        {tripLengths.map(v=><Btn key={v} k="length" v={v}/>)}
+      </div>
+      <div className="flex flex-wrap gap-2 items-center">
+        <span className="text-sm opacity-70 w-24">Season</span>
+        {seasons.map(v=><Btn key={v} k="season" v={v}/>)}
+      </div>
+      <div className="flex flex-wrap gap-2 items-center">
+        <span className="text-sm opacity-70 w-24">Theme</span>
+        {themes.map(v=><Btn key={v} k="theme" v={v}/>)}
+      </div>
+      <div>
+        <button type="button" onClick={()=>onChange({})} className="underline text-sm">Clear filters</button>
+      </div>
+    </div>
+  )
 }

--- a/src/components/FiltersClient.tsx
+++ b/src/components/FiltersClient.tsx
@@ -1,8 +1,0 @@
-'use client'
-
-import Filters from './Filters'
-
-export default function FiltersClient() {
-  return <Filters onChange={() => {}} />
-}
-

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,4 +1,66 @@
+'use client'
 import Image from 'next/image'
+import { useState, useRef, useEffect } from 'react'
+
 export default function Gallery({ images }:{ images:{src:string,alt:string}[] }){
-  return (<div className="grid gap-2 grid-cols-2 md:grid-cols-3">{images.map((img,i)=>(<div key={i} className="relative w-full aspect-[4/3] rounded-xl2 overflow-hidden"><Image src={img.src} alt={img.alt} fill className="object-cover" sizes="(max-width:768px) 50vw, 33vw" loading="lazy"/></div>))}</div>)
+  const [index,setIndex] = useState<number|null>(null)
+  const prevRef = useRef<HTMLButtonElement>(null)
+  const nextRef = useRef<HTMLButtonElement>(null)
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  function open(i:number){ setIndex(i) }
+  function close(){ setIndex(null) }
+  function prev(){ setIndex(i => i===null?null:(i+images.length-1)%images.length) }
+  function next(){ setIndex(i => i===null?null:(i+1)%images.length) }
+
+  useEffect(()=>{
+    if(index!==null){
+      closeRef.current?.focus()
+      const onKey=(e:KeyboardEvent)=>{
+        if(e.key==='Escape') close()
+        if(e.key==='ArrowLeft') prev()
+        if(e.key==='ArrowRight') next()
+        if(e.key==='Tab'){
+          e.preventDefault()
+          const focusables=[prevRef.current!, nextRef.current!, closeRef.current!]
+          const cur=document.activeElement
+          let idx=focusables.indexOf(cur as HTMLButtonElement)
+          const dir=e.shiftKey?-1:1
+          idx=(idx+dir+focusables.length)%focusables.length
+          focusables[idx].focus()
+        }
+      }
+      const nextIndex=(index+1)%images.length
+      const img=new window.Image()
+      img.src=images[nextIndex].src
+      document.addEventListener('keydown',onKey)
+      return()=>document.removeEventListener('keydown',onKey)
+    }
+  },[index,images])
+
+  return (
+    <>
+      <div className="grid gap-2 grid-cols-2 md:grid-cols-3">
+        {images.map((img,i)=>(
+          <button key={i} className="relative w-full aspect-[4/3] rounded-xl2 overflow-hidden" onClick={()=>open(i)}>
+            <Image src={img.src} alt={img.alt} fill className="object-cover" sizes="(max-width:768px) 50vw, 33vw" loading="lazy"/>
+          </button>
+        ))}
+      </div>
+      {index!==null && (
+        <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center">
+          <button ref={closeRef} onClick={close} aria-label="Close" className="absolute top-4 right-4 w-12 h-12 bg-white rounded-full flex items-center justify-center">
+            ✕
+          </button>
+          <button ref={prevRef} onClick={prev} aria-label="Previous" className="absolute left-4 w-12 h-12 bg-white rounded-full flex items-center justify-center">
+            ←
+          </button>
+          <Image src={images[index].src} alt={images[index].alt} width={800} height={600} className="max-h-[80vh] object-contain" />
+          <button ref={nextRef} onClick={next} aria-label="Next" className="absolute right-4 w-12 h-12 bg-white rounded-full flex items-center justify-center">
+            →
+          </button>
+        </div>
+      )}
+    </>
+  )
 }

--- a/src/components/GuidesClient.tsx
+++ b/src/components/GuidesClient.tsx
@@ -1,0 +1,68 @@
+'use client'
+import { useEffect, useState } from 'react'
+import Filters, { FiltersState } from './Filters'
+import GuideCard from './GuideCard'
+import GuidesMap from './GuidesMap'
+import { usePathname, useRouter } from 'next/navigation'
+
+type Guide = {
+  title: string
+  excerpt: string
+  continent: string
+  country: string
+  city: string
+  url: string
+  themes: string[]
+  length: string
+  season: string[]
+  updated: string
+  latitude?: number
+  longitude?: number
+  image: string
+}
+
+export default function GuidesClient(){
+  const [guides,setGuides]=useState<Guide[]>([])
+  const [filters,setFilters]=useState<FiltersState>({})
+  const router=useRouter()
+  const pathname=usePathname()
+
+  useEffect(()=>{
+    fetch('/data/guides.json').then(r=>r.json()).then(setGuides)
+    const params=new URLSearchParams(window.location.search)
+    const init:FiltersState={}
+    const l=params.get('length'); if(l) init.length=l
+    const s=params.get('season'); if(s) init.season=s
+    const t=params.get('theme'); if(t) init.theme=t
+    if(Object.keys(init).length) setFilters(init)
+  },[])
+
+  function handleChange(next:FiltersState){
+    setFilters(next)
+    const params=new URLSearchParams()
+    if(next.length) params.set('length',next.length)
+    if(next.season) params.set('season',next.season)
+    if(next.theme) params.set('theme',next.theme)
+    const qs=params.toString()
+    router.replace(qs?`${pathname}?${qs}`:pathname)
+  }
+
+  const filtered=guides.filter(g=>{
+    if(filters.length && g.length!==filters.length) return false
+    if(filters.season && !g.season.includes(filters.season)) return false
+    if(filters.theme && !g.themes.includes(filters.theme)) return false
+    return true
+  })
+
+  return (
+    <>
+      <Filters state={filters} onChange={handleChange} />
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {filtered.map(g=> (
+          <GuideCard key={g.url} image={g.image} tag={g.continent} title={g.title} excerpt={g.excerpt} href={g.url} />
+        ))}
+      </div>
+      <GuidesMap guides={filtered} />
+    </>
+  )
+}

--- a/src/components/GuidesMap.tsx
+++ b/src/components/GuidesMap.tsx
@@ -1,0 +1,59 @@
+'use client'
+import { useEffect, useRef } from 'react'
+
+type Guide = { title:string; url:string; latitude?:number; longitude?:number }
+
+export default function GuidesMap({ guides }:{guides:Guide[]}){
+  const mapEl = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<any>(null)
+  const markersRef = useRef<any[]>([])
+
+  function addMarkers(){
+    const L=(window as any).L
+    if(!mapRef.current || !L) return
+    markersRef.current.forEach(m=>m.remove())
+    markersRef.current=[]
+    guides.filter(g=>g.latitude&&g.longitude).forEach(g=>{
+      const marker=L.marker([g.latitude,g.longitude]).addTo(mapRef.current)
+      marker.bindPopup(`<a href="${g.url}">${g.title}</a>`)
+      markersRef.current.push(marker)
+    })
+  }
+
+  useEffect(()=>{
+    const el=mapEl.current
+    if(!el) return
+    const observer=new IntersectionObserver(entries=>{
+      if(entries[0].isIntersecting){
+        observer.disconnect()
+        if(mapRef.current) return
+        const link=document.createElement('link')
+        link.rel='stylesheet'
+        link.href='https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'
+        document.head.appendChild(link)
+        const script=document.createElement('script')
+        script.src='https://unpkg.com/leaflet@1.9.4/dist/leaflet.js'
+        script.onload=()=>{
+          const L=(window as any).L
+          mapRef.current=L.map(el).setView([20,0],2)
+          L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{ attribution:'© OpenStreetMap' }).addTo(mapRef.current)
+          addMarkers()
+        }
+        document.body.appendChild(script)
+      }
+    })
+    observer.observe(el)
+    return()=>observer.disconnect()
+  },[])
+
+  useEffect(()=>{ addMarkers() },[guides])
+
+  function reset(){ if(mapRef.current) mapRef.current.setView([20,0],2) }
+
+  return (
+    <div className="my-8">
+      <div ref={mapEl} className="h-96 w-full" id="guides-map" />
+      <button type="button" onClick={reset} className="mt-2 underline text-sm">Reset view</button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- load guides from `/data/guides.json` and render cards with client-side filters and map
- add minimal content to restaurants, resources, credit cards, and gear pages
- implement lightbox gallery and floating back-to-top button

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4c4635b4c8320a70ce9a6bfb4464a