### PR TITLE
Lower homepage logo closer to hero

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
   const featured = posts.slice(0, 6)
   return (
     <main>
-      <section className="relative h-[45vh] md:h-[60vh] mt-12">
+      <section className="relative h-[45vh] md:h-[60vh] mt-2">
         <Image src="/home-hero.svg" alt="Cliffside illustration" fill className="object-cover" priority />
         <div className="absolute inset-0 bg-ink/40" />
         <div className="relative z-10 flex flex-col items-center justify-center h-full text-center text-paper space-y-4 px-4">


### PR DESCRIPTION
## Summary
- Reduce homepage hero's top margin so header logo sits closer to hero

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4edfb2684832081f19c84929a8e10