### PR TITLE
Improve accessibility and add PWA support

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,11 @@
+{
+  "name": "Vacation Avocation",
+  "short_name": "VA",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#F8FAFC",
+  "theme_color": "#6B8E23",
+  "icons": [
+    { "src": "/logo.svg", "sizes": "any", "type": "image/svg+xml" }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,20 @@
+const CACHE_NAME = 'va-static-v1';
+const ASSETS = [
+  '/',
+  '/logo.svg',
+  '/logo-text.svg',
+  '/home-hero.svg'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  color-scheme: light dark;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -25,4 +29,18 @@ h1, h2, h3, h4, h5, h6 {
 
 a:focus-visible, button:focus-visible {
   @apply outline-none ring-2 ring-offset-2 ring-accent1;
+}
+
+.btn {
+  @apply inline-flex items-center justify-center min-w-[44px] min-h-[44px] px-4 py-2 rounded-md hover:bg-brand/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:opacity-50 disabled:cursor-not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
 }

--- a/src/app/guides/[continent]/page.tsx
+++ b/src/app/guides/[continent]/page.tsx
@@ -1,9 +1,20 @@
 import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
 const continents=['africa','asia','europe','north-america','south-america']
 const continentNames:Record<string,string>={'africa':'Africa','asia':'Asia','europe':'Europe','north-america':'North America','south-america':'South America'}
 export async function generateStaticParams(){ return continents.map(c=>({continent:c})) }
 export default function ContinentPage({ params }:{ params:{ continent:string } }){
   const title=continentNames[params.continent] || 'Guides'
   const placeholderCountries=['Country A','Country B','Country C']
-  return (<main className="max-w-6xl mx-auto px-4 py-12"><h1 className="text-3xl font-semibold mb-6">{title}</h1><p className="opacity-80 mb-6">Select a country to view guides. (We’ll replace these placeholders with real countries later.)</p><div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">{placeholderCountries.map((c,i)=>(<div key={i} className="rounded-xl2 border p-4">{c}</div>))}</div><div className="mt-8"><Link href="/guides" className="underline">Back to all continents</Link></div></main>)
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-12">
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides' }, { label: title }]} />
+      <h1 className="text-3xl font-semibold mb-6">{title}</h1>
+      <p className="opacity-80 mb-6">Select a country to view guides. (We’ll replace these placeholders with real countries later.)</p>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {placeholderCountries.map((c,i)=>(<div key={i} className="rounded-xl2 border p-4">{c}</div>))}
+      </div>
+      <div className="mt-8"><Link href="/guides" className="underline">Back to all continents</Link></div>
+    </main>
+  )
 }

--- a/src/app/guides/new-york-weekend/page.tsx
+++ b/src/app/guides/new-york-weekend/page.tsx
@@ -1,4 +1,5 @@
 import Gallery from '@/components/Gallery'
+import Breadcrumbs from '@/components/Breadcrumbs'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = { title: 'Weekend in New York - Vacation Avocation' }
@@ -16,6 +17,7 @@ export default function NewYorkWeekend() {
   ]
   return (
     <main className="container py-12 prose">
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides' }, { label: 'Weekend in New York' }]} />
       <h1>Weekend in New York</h1>
       <p>Quick hits and tasty bites in the Big Apple.</p>
       <Gallery images={images} />

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 
 import GuidesClient from '@/components/GuidesClient'
+import Breadcrumbs from '@/components/Breadcrumbs'
 
 
 export const metadata: Metadata = {
@@ -32,6 +33,7 @@ export const metadata: Metadata = {
 export default function Guides() {
   return (
     <main className="max-w-6xl mx-auto px-4 py-12 space-y-8">
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides' }]} />
       <h1 className="text-3xl font-semibold mb-6">Guides</h1>
 
       <GuidesClient />

--- a/src/app/guides/paris-food/page.tsx
+++ b/src/app/guides/paris-food/page.tsx
@@ -1,4 +1,5 @@
 import Gallery from '@/components/Gallery'
+import Breadcrumbs from '@/components/Breadcrumbs'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = { title: 'Paris Food Guide - Vacation Avocation' }
@@ -16,6 +17,7 @@ export default function ParisFood() {
   ]
   return (
     <main className="container py-12 prose">
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides' }, { label: 'Paris Food Guide' }]} />
       <h1>Paris Food Guide</h1>
       <p>Bistros and bakeries in the City of Light.</p>
       <Gallery images={images} />

--- a/src/app/guides/tokyo-adventure/page.tsx
+++ b/src/app/guides/tokyo-adventure/page.tsx
@@ -1,4 +1,5 @@
 import Gallery from '@/components/Gallery'
+import Breadcrumbs from '@/components/Breadcrumbs'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = { title: 'Tokyo Adventure Guide - Vacation Avocation' }
@@ -16,6 +17,7 @@ export default function TokyoAdventure() {
   ]
   return (
     <main className="container py-12 prose">
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides' }, { label: 'Tokyo Adventure Guide' }]} />
       <h1>Tokyo Adventure Guide</h1>
       <p>High-tech thrills and hidden temples.</p>
       <Gallery images={images} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Poppins, Inter } from 'next/font/google'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import BackToTop from '@/components/BackToTop'
+import PWA from '@/components/PWA'
 
 const poppins = Poppins({ subsets: ['latin'], weight: ['600','700'], variable: '--font-poppins', display: 'swap' })
 const inter = Inter({ subsets: ['latin'], weight: ['400'], variable: '--font-inter', display: 'swap' })
@@ -18,11 +19,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={`${poppins.variable} ${inter.variable}`}>
       <head>
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link rel="manifest" href="/manifest.webmanifest" />
+        <meta name="theme-color" content="#6B8E23" />
       </head>
       <body className="min-h-screen">
         <Header />
         {children}
         <BackToTop />
+        <PWA />
         <Footer />
         <script
           type="application/ld+json"

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -11,8 +11,12 @@ export default function BackToTop(){
   return (
     <button
       type="button"
-      onClick={()=>window.scrollTo({top:0,behavior:'smooth'})}
-      className={`fixed bottom-4 right-4 z-50 p-3 rounded-full bg-brand text-white shadow transition-opacity focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand ${visible?'opacity-100':'opacity-0 pointer-events-none'}`}
+      aria-label="Back to top"
+      onClick={()=>{
+        const prefersReduced=window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        window.scrollTo({top:0,behavior:prefersReduced?'auto':'smooth'})
+      }}
+      className={`btn to-top fixed bottom-4 right-4 z-50 rounded-full bg-brand text-white shadow transition-opacity ${visible?'opacity-100':'opacity-0 pointer-events-none'} w-11 h-11 p-0`}
       aria-hidden={!visible}
       tabIndex={visible?0:-1}
     >

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,44 @@
+'use client'
+import Link from 'next/link'
+
+interface Crumb {
+  label: string
+  href?: string
+}
+
+export default function Breadcrumbs({ items }: { items: Crumb[] }) {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.label,
+      ...(item.href ? { item: item.href } : {}),
+    })),
+  }
+  return (
+    <>
+      <nav aria-label="Breadcrumb" className="text-sm mb-4">
+        <ol className="flex flex-wrap items-center gap-2">
+          {items.map((item, i) => (
+            <li key={i} className="flex items-center gap-2">
+              {item.href ? (
+                <Link href={item.href} className="text-brand hover:underline">
+                  {item.label}
+                </Link>
+              ) : (
+                <span aria-current="page">{item.label}</span>
+              )}
+              {i < items.length - 1 && <span>/</span>}
+            </li>
+          ))}
+        </ol>
+      </nav>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </>
+  )
+}

--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -46,7 +46,7 @@ export default function NewsletterForm() {
       />
       <button
         type="submit"
-        className="px-6 py-3 rounded-xl bg-brand text-white font-semibold hover:bg-brand/90 focus-visible:ring-brand"
+        className="btn bg-brand text-white font-semibold rounded-xl"
       >
         Join Free
       </button>

--- a/src/components/PWA.tsx
+++ b/src/components/PWA.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { useEffect } from 'react'
+
+export default function PWA() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(() => {})
+    }
+  }, [])
+  return null
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -18,3 +18,13 @@
   --font-heading: var(--font-poppins);
   --font-body: var(--font-inter);
 }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --brand: #A6D785;
+    --accent1: #6B8E23;
+    --accent2: #A06B4C;
+    --ink: #F8FAFC;
+    --paper: #0B1220;
+  }
+}


### PR DESCRIPTION
## Summary
- add accessible back-to-top button with reduced-motion check
- introduce dark color scheme, shared button class, and breadcrumbs
- add PWA manifest, service worker, and registration

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4ed1809ac8320b18f8d9c246118f9