### PR TITLE
chore: ignore binary assets in eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+public/
+.next/
+guides-drafts/


### PR DESCRIPTION
## Summary
- prevent eslint from scanning generated or asset directories

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4f0b6dc308320b2aadaf20a5ec6a2