### PR TITLE
Reduce header logo size

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,7 +31,7 @@ export default function Header() {
     <header className="sticky top-0 z-50 bg-paper/80 backdrop-blur border-b border-slate-200">
       <div className="container flex items-center justify-between h-16">
         <Link href="/" className="flex items-center focus-visible:ring-brand">
-          <Image src="/logo-text.svg" alt="Vacation Avocation" width={80} height={20} priority />
+          <Image src="/logo-text.svg" alt="Vacation Avocation" width={78} height={19} priority />
         </Link>
         <nav className="hidden md:flex items-center gap-6 font-heading text-sm" aria-label="Primary">
           {links.map((l) =>


### PR DESCRIPTION
## Summary
- slightly shrink top-left logo in header

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4f42ad8f88320984829b71efdab15