### PR TITLE
fix: shrink header logo

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,7 +31,7 @@ export default function Header() {
     <header className="sticky top-0 z-50 bg-paper/80 backdrop-blur border-b border-slate-200">
       <div className="container flex items-center justify-between h-16">
         <Link href="/" className="flex items-center focus-visible:ring-brand">
-          <Image src="/logo-text.svg" alt="Vacation Avocation" width={78} height={19} priority />
+          <Image src="/logo-text.svg" alt="Vacation Avocation" width={74} height={18} priority />
         </Link>
         <nav className="hidden md:flex items-center gap-6 font-heading text-sm" aria-label="Primary">
           {links.map((l) =>


### PR DESCRIPTION
## Summary
- shrink site logo in header by 5%

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4fc7b2e98832085121723b4b10682