### PR TITLE
fix: prevent stale cache serving old assets

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,20 +1,26 @@
-const CACHE_NAME = 'va-static-v1';
-const ASSETS = [
-  '/',
-  '/logo.svg',
-  '/logo-text.svg',
-  '/home-hero.svg'
-];
+const CACHE_NAME = 'va-static-v1'
+const ASSETS = ['/logo.svg', '/logo-text.svg', '/home-hero.svg']
 
-self.addEventListener('install', event => {
+// Install new service worker and cache core static assets
+self.addEventListener('install', (event) => {
+  self.skipWaiting()
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)))
+})
+
+// Clean up any old caches when activating a new service worker
+self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
-  );
-});
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+    )
+  )
+  self.clients.claim()
+})
 
-self.addEventListener('fetch', event => {
-  if (event.request.method !== 'GET') return;
+// Network‑first strategy to avoid serving stale HTML/JS
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return
   event.respondWith(
-    caches.match(event.request).then(resp => resp || fetch(event.request))
-  );
-});
+    fetch(event.request).catch(() => caches.match(event.request))
+  )
+})


### PR DESCRIPTION
## Summary
- update service worker to avoid stale HTML/JS caches
- clean up old caches and use network-first fetch strategy

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a503566a348320bb4c805f4f919feb