### PR TITLE
feat: auto reload on chunk load errors

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import BackToTop from '@/components/BackToTop'
 import PWA from '@/components/PWA'
+import ChunkErrorReload from '@/components/ChunkErrorReload'
 
 const poppins = Poppins({ subsets: ['latin'], weight: ['600','700'], variable: '--font-poppins', display: 'swap' })
 const inter = Inter({ subsets: ['latin'], weight: ['400'], variable: '--font-inter', display: 'swap' })
@@ -52,6 +53,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {children}
         <BackToTop />
         <PWA />
+        <ChunkErrorReload />
         <Footer />
         <script
           type="application/ld+json"

--- a/src/components/ChunkErrorReload.tsx
+++ b/src/components/ChunkErrorReload.tsx
@@ -1,0 +1,18 @@
+'use client'
+import { useEffect } from 'react'
+
+export default function ChunkErrorReload() {
+  useEffect(() => {
+    const handler = (e: ErrorEvent) => {
+      const isChunkError =
+        e?.message?.includes('Loading chunk') || e?.error?.name === 'ChunkLoadError'
+      if (isChunkError && !sessionStorage.getItem('reloaded-on-chunk-error')) {
+        sessionStorage.setItem('reloaded-on-chunk-error', '1')
+        window.location.reload()
+      }
+    }
+    window.addEventListener('error', handler)
+    return () => window.removeEventListener('error', handler)
+  }, [])
+  return null
+}


### PR DESCRIPTION
## Summary
- add ChunkErrorReload component to force one-time page refresh when a chunk fails to load
- include the component in root layout

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5058f81b8832097490a01c559a05e