### PR TITLE
Use svh units for viewport height

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
   const featured = posts.filter((p) => p.title === 'Pophams London Fields')
   return (
     <main>
-      <section className="relative h-[45vh] md:h-[60vh] mt-2">
+      <section className="relative min-h-[45svh] md:min-h-[60svh] mt-2">
         <Image src="/home-hero.svg" alt="Cliffside illustration" fill className="object-cover" priority />
         <div className="absolute inset-0 bg-ink/40" />
         <div className="relative z-10 flex flex-col items-center justify-center h-full text-center text-paper space-y-4 px-4">

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -55,7 +55,7 @@ export default function Gallery({ images }:{ images:{src:string,alt:string}[] })
           <button ref={prevRef} onClick={prev} aria-label="Previous" className="absolute left-4 w-12 h-12 bg-white rounded-full flex items-center justify-center">
             ←
           </button>
-          <Image src={images[index].src} alt={images[index].alt} width={800} height={600} className="max-h-[80vh] object-contain" />
+          <Image src={images[index].src} alt={images[index].alt} width={800} height={600} className="max-h-[80svh] object-contain" />
           <button ref={nextRef} onClick={next} aria-label="Next" className="absolute right-4 w-12 h-12 bg-white rounded-full flex items-center justify-center">
             →
           </button>


### PR DESCRIPTION
## Summary
- use `svh` units on home hero section to respect dynamic viewport height
- switch gallery modal to `svh` height constraint for better mobile handling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abaca737548320a64febd0bfc59a30