### PR TITLE
Handle safe-area padding for bottom UI elements

### DIFF
--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -16,7 +16,7 @@ export default function BackToTop(){
         const prefersReduced=window.matchMedia('(prefers-reduced-motion: reduce)').matches
         window.scrollTo({top:0,behavior:prefersReduced?'auto':'smooth'})
       }}
-      className={`btn to-top fixed bottom-4 right-4 z-50 rounded-full bg-brand text-white shadow transition-opacity ${visible?'opacity-100':'opacity-0 pointer-events-none'} w-11 h-11 p-0`}
+        className={`btn to-top fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] right-4 z-50 rounded-full bg-brand text-white shadow transition-opacity ${visible?'opacity-100':'opacity-0 pointer-events-none'} w-11 h-11 p-0`}
       aria-hidden={!visible}
       tabIndex={visible?0:-1}
     >

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -54,7 +54,7 @@ export default function CookieConsent() {
   if (!open) return null
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 bg-ink text-paper p-4 text-sm shadow-md">
+    <div className="fixed inset-x-0 bottom-0 z-50 bg-ink text-paper p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] text-sm shadow-md">
       {showSettings ? (
         <div className="space-y-3">
           <p className="font-semibold">Cookie preferences</p>


### PR DESCRIPTION
## Summary
- add safe-area bottom padding to the cookie consent banner
- offset back-to-top button to account for safe-area insets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abacab68d48320b7a0c166b5b68c63