### PR TITLE
Use stable viewport metric for newsletter popup trigger

### DIFF
--- a/src/components/NewsletterPopup.tsx
+++ b/src/components/NewsletterPopup.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 export default function NewsletterPopup(){
   const [open, setOpen] = useState(false)
   useEffect(()=>{
-    function onScroll(){ const scrolled=window.scrollY+window.innerHeight; const half=document.body.scrollHeight*0.5; if(scrolled>=half){ setOpen(true); window.removeEventListener('scroll', onScroll) } }
+      function onScroll(){ const viewport=window.visualViewport?window.visualViewport.height:document.documentElement.clientHeight; const scrolled=window.scrollY+viewport; const half=document.documentElement.scrollHeight*0.5; if(scrolled>=half){ setOpen(true); window.removeEventListener('scroll', onScroll) } }
     window.addEventListener('scroll', onScroll); return ()=>window.removeEventListener('scroll', onScroll)
   },[])
   if(!open) return null


### PR DESCRIPTION
## Summary
- use `visualViewport.height` (with `documentElement.clientHeight` fallback) to determine viewport height
- recalc newsletter popup trigger based on document height

## Testing
- `npm test`
- `npm run build`
- `npx eslint src/components/NewsletterPopup.tsx` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_68abacb3973483208b17a0970c90c160