### PR TITLE
Add active and focus styles for interactive elements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,7 +32,7 @@ a:focus-visible, button:focus-visible {
 }
 
 .btn {
-  @apply inline-flex items-center justify-center min-w-[44px] min-h-[44px] px-4 py-2 rounded-md hover:bg-brand/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:opacity-50 disabled:cursor-not-allowed;
+  @apply inline-flex items-center justify-center min-w-[44px] min-h-[44px] px-4 py-2 rounded-md hover:bg-brand/90 focus:bg-brand/90 active:bg-brand/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:opacity-50 disabled:cursor-not-allowed;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,12 +46,12 @@ export default function Home() {
 
           <p className="text-lg md:text-xl">Food, Fun & Travel</p>
           <div className="flex gap-4 flex-wrap justify-center">
-            <Link href="/guides/london-48h" className="px-6 py-3 rounded-xl bg-brand text-white font-semibold hover:bg-brand/90">
+            <Link href="/guides/london-48h" className="px-6 py-3 rounded-xl bg-brand text-white font-semibold hover:bg-brand/90 focus:bg-brand/90 active:bg-brand/80">
               Start with London
             </Link>
             <Link
               href="/holiday-guides"
-              className="px-6 py-3 rounded-xl bg-accent1 text-white font-semibold hover:bg-accent1/90"
+              className="px-6 py-3 rounded-xl bg-accent1 text-white font-semibold hover:bg-accent1/90 focus:bg-accent1/90 active:bg-accent1/80"
             >
               Holiday Guides
             </Link>

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -24,7 +24,7 @@ export default function Breadcrumbs({ items }: { items: Crumb[] }) {
           {items.map((item, i) => (
             <li key={i} className="flex items-center gap-2">
               {item.href ? (
-                <Link href={item.href} className="text-brand hover:underline">
+                <Link href={item.href} className="text-brand hover:underline focus-visible:underline">
                   {item.label}
                 </Link>
               ) : (

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -20,7 +20,7 @@ export default function Filters({ state, onChange }:{ state:FiltersState, onChan
         type="button"
         onClick={()=>setField(k,v)}
         aria-pressed={active}
-        className={`px-3 py-1.5 rounded-lg border focus-visible:outline focus-visible:outline-2 focus-visible:outline-coral ${active?'bg-coral text-white border-coral':'hover:border-coral'}`}
+        className={`px-3 py-1.5 rounded-lg border focus-visible:outline focus-visible:outline-2 focus-visible:outline-coral ${active?'bg-coral text-white border-coral':'hover:border-coral focus:border-coral active:border-coral'}`}
       >
         {v}
       </button>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,12 +29,12 @@ export default function Footer() {
               <button
                 key={l.label}
                 onClick={l.onClick}
-                className="hover:underline focus-visible:ring-brand"
+                className="hover:underline focus-visible:underline focus-visible:ring-brand"
               >
                 {l.label}
               </button>
             ) : (
-              <Link key={l.href} href={l.href} className="hover:underline focus-visible:ring-brand">
+              <Link key={l.href} href={l.href} className="hover:underline focus-visible:underline focus-visible:ring-brand">
                 {l.label}
               </Link>
             ),
@@ -45,7 +45,7 @@ export default function Footer() {
           <a
             href="https://www.instagram.com/vacationavocation/"
             aria-label="Instagram"
-            className="hover:text-accent2"
+            className="hover:text-accent2 focus-visible:text-accent2 active:text-accent2"
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 24 24">
               <path d="M7.001 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5.001 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7.001zm0 2h10c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3h-10C5.346 20 4 18.654 4 17V7c0-1.654 1.346-3 3.001-3zM12 7a5 5 0 100 10 5 5 0 000-10zm0 2a3 3 0 110 6 3 3 0 010-6zm5.5-2a1.5 1.5 0 11-.001 3.001A1.5 1.5 0 0117.5 7z" />
@@ -54,7 +54,7 @@ export default function Footer() {
           <a
             href="https://www.tiktok.com/@vacationavocation"
             aria-label="TikTok"
-            className="hover:text-accent2"
+            className="hover:text-accent2 focus-visible:text-accent2 active:text-accent2"
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.445-3.375-3.655-5.605-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.823 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z" />

--- a/src/components/GuideCard.tsx
+++ b/src/components/GuideCard.tsx
@@ -13,14 +13,14 @@ export default function GuideCard({ image, tag, title, excerpt, href }: GuideCar
   return (
     <Link
       href={href}
-      className="group rounded-2xl overflow-hidden border border-slate-200 hover:shadow-card transition block bg-paper"
+      className="group rounded-2xl overflow-hidden border border-slate-200 hover:shadow-card active:shadow-card focus-visible:shadow-card transition block bg-paper"
     >
       <div className="relative aspect-[16/9]">
         <Image
           src={image}
           alt={title}
           fill
-          className="object-cover group-hover:scale-105 transition-transform"
+          className="object-cover group-hover:scale-105 group-focus-visible:scale-105 group-active:scale-105 transition-transform"
           sizes="(min-width:1024px) 400px, 100vw"
           loading="lazy"
         />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,7 +32,7 @@ export default function Header() {
             <Link
               key={l.href}
               href={l.href!}
-              className={`${pathname === l.href ? 'text-brand font-semibold' : 'hover:text-brand'}`}
+              className={`${pathname === l.href ? 'text-brand font-semibold' : 'hover:text-brand focus-visible:text-brand active:text-brand'}`}
               aria-current={pathname === l.href ? 'page' : undefined}
             >
               {l.label}
@@ -41,7 +41,7 @@ export default function Header() {
           <a
             href="https://www.instagram.com/vacationavocation/"
             aria-label="Instagram"
-            className="hover:text-brand"
+            className="hover:text-brand focus-visible:text-brand active:text-brand"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -56,7 +56,7 @@ export default function Header() {
           <a
             href="https://www.tiktok.com/@vacationavocation"
             aria-label="TikTok"
-            className="hover:text-brand"
+            className="hover:text-brand focus-visible:text-brand active:text-brand"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -68,7 +68,7 @@ export default function Header() {
               <path d="M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.445-3.375-3.655-5.605-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z" />
             </svg>
           </a>
-          <Link href="/search" aria-label="Search" className="hover:text-brand">
+          <Link href="/search" aria-label="Search" className="hover:text-brand focus-visible:text-brand active:text-brand">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="20"
@@ -123,7 +123,7 @@ export default function Header() {
               <li key={l.label}>
                 <Link
                   href={l.href!}
-                  className="block hover:text-brand"
+                  className="block hover:text-brand focus-visible:text-brand active:text-brand"
                   onClick={() => setOpen(false)}
                 >
                   {l.label}
@@ -134,7 +134,7 @@ export default function Header() {
               <a
                 href="https://www.instagram.com/vacationavocation/"
                 aria-label="Instagram"
-                className="block hover:text-brand"
+                className="block hover:text-brand focus-visible:text-brand active:text-brand"
                 onClick={() => setOpen(false)}
               >
                 <svg
@@ -153,7 +153,7 @@ export default function Header() {
               <a
                 href="https://www.tiktok.com/@vacationavocation"
                 aria-label="TikTok"
-                className="block hover:text-brand"
+                className="block hover:text-brand focus-visible:text-brand active:text-brand"
                 onClick={() => setOpen(false)}
               >
                 <svg
@@ -171,7 +171,7 @@ export default function Header() {
             <li>
               <Link
                 href="/search"
-                className="block hover:text-brand"
+                className="block hover:text-brand focus-visible:text-brand active:text-brand"
                 onClick={() => setOpen(false)}
               >
                 Search

--- a/src/components/TagChip.tsx
+++ b/src/components/TagChip.tsx
@@ -11,7 +11,7 @@ export default function TagChip({ label, active, onClick }: Props) {
     <button
       onClick={onClick}
       aria-pressed={active}
-      className={`px-4 py-2 rounded-full text-sm font-medium border transition-colors ${active ? 'bg-brand text-white border-brand' : 'border-ink/20 text-ink hover:bg-ink/5'}`}
+      className={`px-4 py-2 rounded-full text-sm font-medium border transition-colors ${active ? 'bg-brand text-white border-brand' : 'border-ink/20 text-ink hover:bg-ink/5 active:bg-ink/10'}`}
     >
       {label}
     </button>


### PR DESCRIPTION
## Summary
- strengthen `.btn` with active and focus background utilities
- expand TagChip and other components to include focus/active states alongside hover
- adjust hero links for better interaction parity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abacc044b08320b29563a7157978a8